### PR TITLE
railsのように最新のshemaを出力して見れるようにする

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -59,6 +59,7 @@ schema-show:
 	done
 
 schema-dump:
+	@mkdir -p pkg
 	@echo "=== 最新スキーマ情報をpkg/schema.txtに出力中 ===" > pkg/schema.txt
 	@echo "Generated at: $$(date '+%Y-%m-%d %H:%M:%S')" >> pkg/schema.txt
 	@echo "Latest migration: $$(goose -dir migration postgres "$(GOOSE_DBSTRING)" status | tail -1 | awk '{print $$NF}')" >> pkg/schema.txt

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -45,3 +45,41 @@ wire-gen-usecase:
 	wire gen ./core/usecase
 wire-gen-injector:
 	wire gen ./core/injector
+
+# スキーマ確認コマンド
+schema-show:
+	@echo "=== テーブル一覧 ==="
+	@psql "$(GOOSE_DBSTRING)" -c "\dt"
+	@echo ""
+	@echo "=== 全テーブル詳細 ==="
+	@for table in $$(psql "$(GOOSE_DBSTRING)" -t -c "SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename != 'goose_db_version';"); do \
+		echo "--- $$table ---"; \
+		psql "$(GOOSE_DBSTRING)" -c "\d $$table"; \
+		echo ""; \
+	done
+
+schema-dump:
+	@echo "=== 最新スキーマ情報をpkg/schema.txtに出力中 ===" > pkg/schema.txt
+	@echo "Generated at: $$(date '+%Y-%m-%d %H:%M:%S')" >> pkg/schema.txt
+	@echo "Latest migration: $$(goose -dir migration postgres "$(GOOSE_DBSTRING)" status | tail -1 | awk '{print $$NF}')" >> pkg/schema.txt
+	@echo "" >> pkg/schema.txt
+	@echo "=== テーブル一覧 ===" >> pkg/schema.txt
+	@psql "$(GOOSE_DBSTRING)" -c "\dt" >> pkg/schema.txt 2>/dev/null
+	@echo "" >> pkg/schema.txt
+	@echo "=== 全テーブル詳細 ===" >> pkg/schema.txt
+	@for table in $$(psql "$(GOOSE_DBSTRING)" -t -c "SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename != 'goose_db_version';"); do \
+		echo "" >> pkg/schema.txt; \
+		echo "--- $$table ---" >> pkg/schema.txt; \
+		psql "$(GOOSE_DBSTRING)" -c "\d $$table" >> pkg/schema.txt 2>/dev/null; \
+	done
+	@echo ""
+	@echo "✅ Schema saved to pkg/schema.txt"
+
+schema-simple:
+	@echo "=== 最新スキーマ一覧 ==="
+	@for table in $$(psql "$(GOOSE_DBSTRING)" -t -c "SELECT tablename FROM pg_tables WHERE schemaname='public' AND tablename != 'goose_db_version' ORDER BY tablename;"); do \
+		echo ""; \
+		echo "📋 Table: $$table"; \
+		echo "────────────────────────────────────────"; \
+		psql "$(GOOSE_DBSTRING)" -c "SELECT column_name, data_type, is_nullable, column_default FROM information_schema.columns WHERE table_name='$$table' ORDER BY ordinal_position;" --quiet; \
+	done

--- a/backend/pkg/schema.txt
+++ b/backend/pkg/schema.txt
@@ -1,0 +1,219 @@
+=== 最新スキーマ情報をpkg/schema.txtに出力中 ===
+Generated at: 2025-07-18 13:17:46
+Latest migration: 
+
+=== テーブル一覧 ===
+              List of relations
+ Schema |       Name        | Type  |  Owner  
+--------+-------------------+-------+---------
+ public | authors           | table | yondeco
+ public | goose_db_version  | table | yondeco
+ public | kindle_highlights | table | yondeco
+ public | master_books      | table | yondeco
+ public | ocr_texts         | table | yondeco
+ public | publishers        | table | yondeco
+ public | randoku_images    | table | yondeco
+ public | randoku_memos     | table | yondeco
+ public | reading_history   | table | yondeco
+ public | seidoku_memos     | table | yondeco
+ public | user_book_logs    | table | yondeco
+ public | users             | table | yondeco
+(12 rows)
+
+
+=== 全テーブル詳細 ===
+
+--- users ---
+                                   Table "public.users"
+    Column    |            Type             | Collation | Nullable |        Default        
+--------------+-----------------------------+-----------+----------+-----------------------
+ ulid         | text                        |           | not null | 
+ display_name | character varying(100)      |           | not null | ''::character varying
+ deleted_at   | timestamp without time zone |           |          | 
+ created_at   | timestamp without time zone |           | not null | statement_timestamp()
+ updated_at   | timestamp without time zone |           | not null | statement_timestamp()
+ uid          | character varying(255)      |           | not null | ''::character varying
+Indexes:
+    "users_pkey" PRIMARY KEY, btree (ulid)
+Referenced by:
+    TABLE "reading_history" CONSTRAINT "reading_history_user_ulid_fkey" FOREIGN KEY (user_ulid) REFERENCES users(ulid)
+    TABLE "user_book_logs" CONSTRAINT "user_book_logs_user_ulid_fkey" FOREIGN KEY (user_ulid) REFERENCES users(ulid)
+
+
+--- authors ---
+                                        Table "public.authors"
+   Column   |            Type             | Collation | Nullable |               Default               
+------------+-----------------------------+-----------+----------+-------------------------------------
+ id         | bigint                      |           | not null | nextval('authors_id_seq'::regclass)
+ name       | character varying(100)      |           | not null | ''::character varying
+ created_at | timestamp without time zone |           | not null | statement_timestamp()
+ updated_at | timestamp without time zone |           | not null | statement_timestamp()
+Indexes:
+    "authors_pkey" PRIMARY KEY, btree (id)
+Referenced by:
+    TABLE "master_books" CONSTRAINT "master_books_author_id_fkey" FOREIGN KEY (author_id) REFERENCES authors(id)
+
+
+--- publishers ---
+                                        Table "public.publishers"
+   Column   |            Type             | Collation | Nullable |                Default                 
+------------+-----------------------------+-----------+----------+----------------------------------------
+ id         | bigint                      |           | not null | nextval('publishers_id_seq'::regclass)
+ name       | character varying(100)      |           | not null | ''::character varying
+ created_at | timestamp without time zone |           | not null | statement_timestamp()
+ updated_at | timestamp without time zone |           | not null | statement_timestamp()
+Indexes:
+    "publishers_pkey" PRIMARY KEY, btree (id)
+Referenced by:
+    TABLE "master_books" CONSTRAINT "master_books_publisher_id_fkey" FOREIGN KEY (publisher_id) REFERENCES publishers(id)
+
+
+--- master_books ---
+                                         Table "public.master_books"
+    Column    |            Type             | Collation | Nullable |                 Default                  
+--------------+-----------------------------+-----------+----------+------------------------------------------
+ id           | bigint                      |           | not null | nextval('master_books_id_seq'::regclass)
+ isbn         | character varying(13)       |           | not null | ''::character varying
+ cover_s3_url | character varying(255)      |           | not null | ''::character varying
+ title        | character varying(60)       |           | not null | ''::character varying
+ author_id    | bigint                      |           | not null | 
+ publisher_id | bigint                      |           | not null | 
+ total_page   | integer                     |           | not null | 20
+ created_at   | timestamp without time zone |           | not null | statement_timestamp()
+ updated_at   | timestamp without time zone |           | not null | statement_timestamp()
+ published_at | date                        |           |          | 
+Indexes:
+    "master_books_pkey" PRIMARY KEY, btree (id)
+Foreign-key constraints:
+    "master_books_author_id_fkey" FOREIGN KEY (author_id) REFERENCES authors(id)
+    "master_books_publisher_id_fkey" FOREIGN KEY (publisher_id) REFERENCES publishers(id)
+Referenced by:
+    TABLE "kindle_highlights" CONSTRAINT "kindle_highlights_master_book_id_fkey" FOREIGN KEY (master_book_id) REFERENCES master_books(id)
+    TABLE "user_book_logs" CONSTRAINT "user_book_logs_master_book_id_fkey" FOREIGN KEY (master_book_id) REFERENCES master_books(id)
+
+
+--- randoku_images ---
+                                 Table "public.randoku_images"
+      Column       |            Type             | Collation | Nullable |        Default        
+-------------------+-----------------------------+-----------+----------+-----------------------
+ ulid              | text                        |           | not null | 
+ user_book_logs_id | bigint                      |           | not null | 0
+ is_bookmark       | boolean                     |           | not null | false
+ s3_url            | character varying(255)      |           | not null | ''::character varying
+ thumbnail_s3_url  | character varying(255)      |           | not null | ''::character varying
+ name              | character varying(255)      |           | not null | ''::character varying
+ is_already_read   | boolean                     |           | not null | false
+ created_at        | timestamp without time zone |           | not null | statement_timestamp()
+ updated_at        | timestamp without time zone |           | not null | statement_timestamp()
+Indexes:
+    "randoku_images_pkey" PRIMARY KEY, btree (ulid)
+Foreign-key constraints:
+    "randoku_images_user_book_logs_id_fkey" FOREIGN KEY (user_book_logs_id) REFERENCES user_book_logs(id)
+Referenced by:
+    TABLE "ocr_texts" CONSTRAINT "ocr_texts_randoku_img_ulid_fkey" FOREIGN KEY (randoku_img_ulid) REFERENCES randoku_images(ulid)
+
+
+--- randoku_memos ---
+                                            Table "public.randoku_memos"
+      Column       |            Type             | Collation | Nullable |                  Default                  
+-------------------+-----------------------------+-----------+----------+-------------------------------------------
+ id                | bigint                      |           | not null | nextval('randoku_memos_id_seq'::regclass)
+ user_book_logs_id | bigint                      |           | not null | 
+ content           | text                        |           | not null | ''::text
+ content_tag       | integer                     |           | not null | 0
+ created_at        | timestamp without time zone |           | not null | statement_timestamp()
+ updated_at        | timestamp without time zone |           | not null | statement_timestamp()
+Indexes:
+    "randoku_memos_pkey" PRIMARY KEY, btree (id)
+Foreign-key constraints:
+    "randoku_memos_user_book_logs_id_fkey" FOREIGN KEY (user_book_logs_id) REFERENCES user_book_logs(id)
+
+
+--- user_book_logs ---
+                                          Table "public.user_book_logs"
+     Column     |            Type             | Collation | Nullable |                  Default                   
+----------------+-----------------------------+-----------+----------+--------------------------------------------
+ id             | bigint                      |           | not null | nextval('user_book_logs_id_seq'::regclass)
+ user_ulid      | text                        |           | not null | 
+ master_book_id | bigint                      |           | not null | 
+ status         | reading_type                |           | not null | 'smooth_randoku'::reading_type
+ is_seidoku_key | boolean                     |           | not null | false
+ registered_at  | date                        |           | not null | 
+ created_at     | timestamp without time zone |           | not null | statement_timestamp()
+Indexes:
+    "user_book_logs_pkey" PRIMARY KEY, btree (id)
+    "user_book_logs_user_ulid_master_book_id_key" UNIQUE CONSTRAINT, btree (user_ulid, master_book_id)
+Foreign-key constraints:
+    "user_book_logs_master_book_id_fkey" FOREIGN KEY (master_book_id) REFERENCES master_books(id)
+    "user_book_logs_user_ulid_fkey" FOREIGN KEY (user_ulid) REFERENCES users(ulid)
+Referenced by:
+    TABLE "randoku_images" CONSTRAINT "randoku_images_user_book_logs_id_fkey" FOREIGN KEY (user_book_logs_id) REFERENCES user_book_logs(id)
+    TABLE "randoku_memos" CONSTRAINT "randoku_memos_user_book_logs_id_fkey" FOREIGN KEY (user_book_logs_id) REFERENCES user_book_logs(id)
+    TABLE "seidoku_memos" CONSTRAINT "seidoku_memos_user_book_logs_id_fkey" FOREIGN KEY (user_book_logs_id) REFERENCES user_book_logs(id)
+
+
+--- seidoku_memos ---
+                                            Table "public.seidoku_memos"
+      Column       |            Type             | Collation | Nullable |                  Default                  
+-------------------+-----------------------------+-----------+----------+-------------------------------------------
+ id                | bigint                      |           | not null | nextval('seidoku_memos_id_seq'::regclass)
+ user_book_logs_id | bigint                      |           | not null | 
+ content           | text                        |           | not null | ''::text
+ content_tag       | integer                     |           | not null | 0
+ created_at        | timestamp without time zone |           | not null | statement_timestamp()
+ updated_at        | timestamp without time zone |           | not null | statement_timestamp()
+Indexes:
+    "seidoku_memos_pkey" PRIMARY KEY, btree (id)
+Foreign-key constraints:
+    "seidoku_memos_user_book_logs_id_fkey" FOREIGN KEY (user_book_logs_id) REFERENCES user_book_logs(id)
+
+
+--- reading_history ---
+                                         Table "public.reading_history"
+   Column    |            Type             | Collation | Nullable |                   Default                   
+-------------+-----------------------------+-----------+----------+---------------------------------------------
+ id          | bigint                      |           | not null | nextval('reading_history_id_seq'::regclass)
+ user_ulid   | text                        |           | not null | 
+ content_url | character varying(255)      |           | not null | ''::character varying
+ recorded_at | timestamp without time zone |           | not null | statement_timestamp()
+ created_at  | timestamp without time zone |           | not null | statement_timestamp()
+Indexes:
+    "reading_history_pkey" PRIMARY KEY, btree (id)
+Foreign-key constraints:
+    "reading_history_user_ulid_fkey" FOREIGN KEY (user_ulid) REFERENCES users(ulid)
+
+
+--- ocr_texts ---
+                                           Table "public.ocr_texts"
+      Column      |            Type             | Collation | Nullable |                Default                
+------------------+-----------------------------+-----------+----------+---------------------------------------
+ id               | bigint                      |           | not null | nextval('ocr_texts_id_seq'::regclass)
+ randoku_img_ulid | text                        |           | not null | 
+ text             | character varying(255)      |           | not null | ''::character varying
+ created_at       | timestamp without time zone |           | not null | statement_timestamp()
+ updated_at       | timestamp without time zone |           | not null | statement_timestamp()
+Indexes:
+    "ocr_texts_pkey" PRIMARY KEY, btree (id)
+    "ocr_texts_randoku_img_ulid_key" UNIQUE CONSTRAINT, btree (randoku_img_ulid)
+Foreign-key constraints:
+    "ocr_texts_randoku_img_ulid_fkey" FOREIGN KEY (randoku_img_ulid) REFERENCES randoku_images(ulid)
+
+
+--- kindle_highlights ---
+                                          Table "public.kindle_highlights"
+     Column     |            Type             | Collation | Nullable |                    Default                    
+----------------+-----------------------------+-----------+----------+-----------------------------------------------
+ id             | bigint                      |           | not null | nextval('kindle_highlights_id_seq'::regclass)
+ master_book_id | bigint                      |           | not null | 
+ position       | integer                     |           | not null | 0
+ highlight      | text                        |           | not null | ''::text
+ memo           | text                        |           | not null | ''::text
+ last_synced_at | date                        |           | not null | 
+ created_at     | timestamp without time zone |           | not null | statement_timestamp()
+ updated_at     | timestamp without time zone |           | not null | statement_timestamp()
+Indexes:
+    "kindle_highlights_pkey" PRIMARY KEY, btree (id)
+    "kindle_highlights_master_book_id_position_key" UNIQUE CONSTRAINT, btree (master_book_id, "position")
+Foreign-key constraints:
+    "kindle_highlights_master_book_id_fkey" FOREIGN KEY (master_book_id) REFERENCES master_books(id)
+

--- a/backend/scripts/generate_schema.sh
+++ b/backend/scripts/generate_schema.sh
@@ -3,10 +3,9 @@ set -euo pipefail
 
 # Goose + PostgreSQL用のschema.sql自動生成スクリプト
 # Rails schema.rbと同様の機能を提供
+# pkg/schema.txtとして出力
 
 DB_URL="${DB_URL:-postgres://yondeco:yondeco@localhost:5432/yondeco?sslmode=disable}"
-# Or: allow passing as first argument
-# DB_URL="${1:?usage: $0 <postgres_dsn>}"
 OUTPUT_FILE="schema.sql"
 
 # 現在の日時を取得

--- a/backend/scripts/generate_schema.sh
+++ b/backend/scripts/generate_schema.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
+set -euo pipefail
 
 # Goose + PostgreSQL用のschema.sql自動生成スクリプト
 # Rails schema.rbと同様の機能を提供
 
-DB_URL="postgres://yondeco:yondeco@localhost:5432/yondeco?sslmode=disable"
+DB_URL="${DB_URL:-postgres://yondeco:yondeco@localhost:5432/yondeco?sslmode=disable}"
+# Or: allow passing as first argument
+# DB_URL="${1:?usage: $0 <postgres_dsn>}"
 OUTPUT_FILE="schema.sql"
 
 # 現在の日時を取得

--- a/backend/scripts/generate_schema.sh
+++ b/backend/scripts/generate_schema.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Goose + PostgreSQL用のschema.sql自動生成スクリプト
+# Rails schema.rbと同様の機能を提供
+
+DB_URL="postgres://yondeco:yondeco@localhost:5432/yondeco?sslmode=disable"
+OUTPUT_FILE="schema.sql"
+
+# 現在の日時を取得
+TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
+
+# 最新のマイグレーションバージョンを取得
+LATEST_VERSION=$(goose -dir migration postgres "$DB_URL" status | grep "Applied At" -A 100 | tail -1 | awk '{print $NF}' | sed 's/--//' | awk '{print $1}')
+
+# ヘッダーコメントを生成
+cat > "$OUTPUT_FILE" << EOF
+-- This file is auto-generated from the current state of the database. Instead
+-- of editing this file, please use the goose migrations feature to 
+-- incrementally modify your database, and then regenerate this schema definition.
+--
+-- This file represents the schema when all migrations have been applied.
+-- When creating a new database, you can load this schema directly instead of
+-- running all migrations from scratch.
+--
+-- It's strongly recommended that you check this file into your version control system.
+--
+-- Generated at: $TIMESTAMP
+-- Latest migration: $LATEST_VERSION
+
+-- Extensions (if any)
+EOF
+
+# ENUM型を追加
+echo "" >> "$OUTPUT_FILE"
+echo "-- Custom types" >> "$OUTPUT_FILE"
+psql "$DB_URL" -t -c "SELECT 'CREATE TYPE ' || typname || ' AS ENUM (' || string_agg('''' || enumlabel || '''', ', ') || ');' FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid GROUP BY typname;" | grep -v "^$" >> "$OUTPUT_FILE"
+
+# テーブル構造をダンプ（外部キー制約は除く）
+echo "" >> "$OUTPUT_FILE"
+echo "-- Tables" >> "$OUTPUT_FILE"
+pg_dump --schema-only --no-owner --no-privileges --no-comments \
+  "$DB_URL" \
+  | grep -v "CREATE TYPE" \
+  | grep -v "ALTER TYPE" \
+  | grep -v "goose_db_version" \
+  | sed '/^$/N;/^\n$/d' \
+  >> "$OUTPUT_FILE"
+
+echo ""
+echo "✅ Schema generated successfully: $OUTPUT_FILE"
+echo "📄 Latest migration: $LATEST_VERSION"
+echo "🕐 Generated at: $TIMESTAMP"


### PR DESCRIPTION
railsのmigration後のように、常に最新のshemaファイルを見れるようにする
`make schema-dump`で実行

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new commands for inspecting and exporting the database schema, including detailed and simplified schema views, and the ability to generate a comprehensive schema report.
  * Introduced a script to automate the generation of a PostgreSQL schema SQL file.
  * Added a full database schema reference file for easy review of tables, columns, constraints, and relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->